### PR TITLE
Bug fixes

### DIFF
--- a/src/ng-truncate.parser.e2e.spec.ts
+++ b/src/ng-truncate.parser.e2e.spec.ts
@@ -13,9 +13,63 @@ describe('DoorgetsTruncateParser', () => {
   });
 
   it('should parse sentence', () => {
-      expect(parser.parse("Hello")).toEqual("Hello");
-      expect(parser.parse("Hello", {
-        limit: 1
-      })).toEqual("H...");
+    expect(parser.parse("Hello")).toEqual("Hello");
+    expect(parser.parse("Hello", {
+      limit: 1
+    })).toEqual("H...");
   });
+
+  it('should handle limits equal to string length (odd) if position is center', () => {
+    let testString = "Limit equals to string length ";
+    expect(parser.parse(testString, {
+      limit: testString.length,
+      position: 'center'
+    })).toEqual(testString);
+  });
+
+  it('should handle limits equal to string length (even) if position is center', () => {
+    let testString = "Limit equals to string length";
+    expect(parser.parse(testString, {
+      limit: testString.length,
+      position: 'center'
+    })).toEqual(testString);
+  });
+
+  it('results for odd and even limits for the same string (position: center) shall be different and proportionally', () => {
+    let testString = "This is a sample string";
+    let parseEvenLimit = (parser.parse(testString, {
+        limit: 4,
+        position: 'center'
+    }));
+    let parseOddLimit = (parser.parse(testString, {
+      limit: 5,
+      position: 'center'
+    }));
+
+    expect(parseEvenLimit === parseOddLimit).toBeFalsy();
+  });
+
+  it('results for nearest greater odd limit shall be longer that results for an even limit if position is the input is 1 character longer than the biggest limit', () => {
+    let testString = "This is a sample string";
+    let parseEvenLimit = (parser.parse(testString, {
+      limit: 4,
+      position: 'center'
+    }));
+
+    let parseOddLimit = (parser.parse(testString, {
+      limit: 5,
+      position: 'center'
+    }));
+
+    expect(parseEvenLimit.length).toBeLessThan(parseOddLimit.length);
+  });
+
+  it('even limits should be correctly handled if position is center', () => {
+    let testString = "This is a sample string";
+    expect(parser.parse(testString, {
+      limit: 5,
+      position: 'center'
+    })).toEqual("Thi...ng");
+  });
+
 });

--- a/src/ng-truncate.parser.e2e.spec.ts
+++ b/src/ng-truncate.parser.e2e.spec.ts
@@ -35,7 +35,7 @@ describe('DoorgetsTruncateParser', () => {
     })).toEqual(testString);
   });
 
-  it('results for odd and even limits for the same string (position: center) shall be different and proportionally', () => {
+  it('results for odd and even limits for the same string (position: center) shall be different', () => {
     let testString = "This is a sample string";
     let parseEvenLimit = (parser.parse(testString, {
         limit: 4,
@@ -49,7 +49,7 @@ describe('DoorgetsTruncateParser', () => {
     expect(parseEvenLimit === parseOddLimit).toBeFalsy();
   });
 
-  it('results for nearest greater odd limit shall be longer that results for an even limit if position is the input is 1 character longer than the biggest limit', () => {
+  it('results for nearest greater odd limit shall be longer than results for an even limit if position is center and the input is 1 character longer than the biggest specified limit', () => {
     let testString = "This is a sample string";
     let parseEvenLimit = (parser.parse(testString, {
       limit: 4,

--- a/src/ng-truncate.parser.ts
+++ b/src/ng-truncate.parser.ts
@@ -44,7 +44,7 @@ export class DoorgetsTruncateParser {
     const keys = sentence.split(splitTag);
     if (keys.length > _option.limit) {
       if (isMiddleOption) {
-        prefix = keys.slice(0, _option.limit / 2).join(joinTag);
+        prefix = keys.slice(0, _option.limit % 2 == 0 ? _option.limit / 2 : _option.limit / 2 + 1).join(joinTag);
         suffix = keys.reverse().slice(0, _option.limit / 2).reverse().join(joinTag);
       } else {
         sentence = keys.slice(0, _option.limit).join(joinTag);
@@ -55,7 +55,7 @@ export class DoorgetsTruncateParser {
       case 'left':
         return _option.trail + sentence;
       case 'center':
-        return prefix + _option.trail  + suffix;
+        return (prefix || suffix) ? prefix + _option.trail + suffix : sentence;
       default:
         return sentence + _option.trail;
     }


### PR DESCRIPTION
A strange behaviour has been identified in case one provides a string having length equal to 'limit' and position: 'center'. In such case the result for string "This is sample" and limit 14 was always "...".

Another potential issue approached - handling of odd and even limits for the same string if the position is "center".

Could you please consider a review?

Thank you.